### PR TITLE
code to validate Linux system

### DIFF
--- a/main.go
+++ b/main.go
@@ -48,7 +48,7 @@ const DEFAULT_REFRESH = 5 // default refresh interval in seconds
 
 func usage(code int) {
 	fmt.Printf(
-`rtop %s - (c) 2015 RapidLoop - MIT Licensed - http://rtop-monitor.org
+		`rtop %s - (c) 2015 RapidLoop - MIT Licensed - http://rtop-monitor.org
 rtop monitors server statistics over an ssh connection
 
 Usage: rtop [-i private-key-file] [user@]host[:port] [interval]
@@ -144,6 +144,21 @@ func parseCmdLine() (key, username, addr string, interval time.Duration) {
 	return
 }
 
+//rtop only support for Linux system
+func validateOS(client *ssh.Client) {
+	ostype, err := runCommand(client, "uname")
+	if err != nil {
+		os.Exit(1)
+	}
+	//remove newline character
+	ostype = strings.Trim(ostype, "\n")
+
+	if !strings.EqualFold(ostype, "Linux") {
+		fmt.Println("\nrtop not support for ", ostype, "system\n")
+		os.Exit(1)
+	}
+}
+
 //----------------------------------------------------------------------------
 
 func main() {
@@ -154,6 +169,7 @@ func main() {
 	keyPath, username, addr, interval := parseCmdLine()
 
 	client := sshConnect(username, addr, keyPath)
+	validateOS(client)
 
 	// the loop
 	showStats(client)
@@ -177,7 +193,7 @@ func showStats(client *ssh.Client) {
 	getAllStats(client, &stats)
 	used := stats.MemTotal - stats.MemFree - stats.MemBuffers - stats.MemCached
 	fmt.Printf(
-`%s%s%s%s up %s%s%s
+		`%s%s%s%s up %s%s%s
 
 Load:
     %s%s %s %s%s


### PR DESCRIPTION
Document mentioned that rtop only support for Linux machine, so when we give host other than  Linux it has to report like unsupported. But it displaying 0 value now.

Code change:
=============
check the operating system type through uname command


Test for IBM-AIX machine
=====================
localhost-~/sujin/og/rtop: rtop sujin@10.45.5.99
sujin@10.45.5.99's password:
 up 0

Load:


CPU:
    0.00% user, 0.00% sys, 0.00% nice, 0.00% idle, 0.00% iowait, 0.00% hardirq, 0.00% softirq, 0.00% guest

Processes:
     running of  total

Memory:
    free    = 0 bytes
    used    = 0 bytes
    buffers = 0 bytes
    cached  = 0 bytes
    swap    = 0 bytes free of 0 bytes

 
After change:
===========
localhost-~/sujin/og/rtop: rtop sujin@10.45.5.99
sujin@10.45.5.99's password:

rtop not support for  AIX system
