### PR TITLE
Expand user home directory

### DIFF
--- a/sshhelper.go
+++ b/sshhelper.go
@@ -36,7 +36,6 @@ import (
 	"net"
 	"os"
 	"os/signal"
-	"os/user"
 	"strings"
 	"syscall"
 
@@ -101,21 +100,11 @@ func ParsePemBlock(block *pem.Block) (interface{}, error) {
 
 func expandPath(path string) string {
 
-	if len(path) < 2 {
+	if len(path) < 2 || path[:2] != "~/" {
 		return path
 	}
 
-	if path[:2] != "~/" {
-		return path
-	}
-
-	usr, err := user.Current()
-
-	if err != nil {
-		return path
-	}
-
-	return strings.Replace(path, "~", usr.HomeDir, 1)
+	return strings.Replace(path, "~", currentUser.HomeDir, 1)
 }
 
 func addKeyAuth(auths []ssh.AuthMethod, keypath string) []ssh.AuthMethod {

--- a/sshhelper.go
+++ b/sshhelper.go
@@ -36,6 +36,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"os/user"
 	"strings"
 	"syscall"
 
@@ -98,10 +99,31 @@ func ParsePemBlock(block *pem.Block) (interface{}, error) {
 	}
 }
 
+func expandPath(path string) string {
+
+	if len(path) < 2 {
+		return path
+	}
+
+	if path[:2] != "~/" {
+		return path
+	}
+
+	usr, err := user.Current()
+
+	if err != nil {
+		return path
+	}
+
+	return strings.Replace(path, "~", usr.HomeDir, 1)
+}
+
 func addKeyAuth(auths []ssh.AuthMethod, keypath string) []ssh.AuthMethod {
 	if len(keypath) == 0 {
 		return auths
 	}
+
+	keypath = expandPath(keypath)
 
 	// read the file
 	pemBytes, err := ioutil.ReadFile(keypath)


### PR DESCRIPTION
When reading from `.ssh/config` go is unable to read keys like: `~/.ssh/id_rsa`. This code expands the path names to `/home/my_user/.ssh/id_rsa`.

That way go is able to work with the path name :).