### PR TITLE
Updated install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ and screenshots!*
 `rtop` is written in [go](http://golang.org/), and requires Go version 1.2
 or higher. To build, `go get` it:
 
-    go get github.com/rapidloop/rtop
+    go install github.com/rapidloop/rtop@latest
 
 You should find the binary `rtop` under `$GOPATH/bin` when the command
 completes. There are no runtime dependencies or configuration needed.


### PR DESCRIPTION
According to the command line error, the correct syntax is now `go install github.com/rapidloop/rtop@latest`. Once I adjusted for this, it allowed me to download it direct from the repo.